### PR TITLE
Add a new boolean fcl parameter for GENIEHelper. The parameter toggles

### DIFF
--- a/nugen/EventGeneratorBase/GENIE/GENIEHelper.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GENIEHelper.cxx
@@ -272,6 +272,7 @@ namespace evgb {
     , fGHepPrintLevel    (pset.get< int                      >("GHepPrintLevel",     -1) ) // see GHepRecord::SetPrintLevel() -1=no-print
     , fMixerConfig       (pset.get< std::string              >("MixerConfig",    "none") )
     , fMixerBaseline     (pset.get< double                   >("MixerBaseline",      0.) )
+    , fUseBlenderDist    (pset.get< bool                     >("UseBlenderDist",     true) )
     , fFiducialCut       (pset.get< std::string              >("FiducialCut",    "none") )
     , fGeomScan          (pset.get< std::string              >("GeomScan",    "default") )
     , fDebugFlags        (pset.get< unsigned int             >("DebugFlags",          0) )
@@ -1695,7 +1696,7 @@ namespace evgb {
     genie::flux::GFluxBlender* blender =
       dynamic_cast<genie::flux::GFluxBlender*>(fFluxD2GMCJD);
     if ( blender ) {
-      flux.fdk2gen = blender->TravelDist();
+      if ( fUseBlenderDist ) flux.fdk2gen = blender->TravelDist();
       // / if mixing flavors print the state of the blender
       if ( fDebugFlags & 0x02 ) blender->PrintState();
     }

--- a/nugen/EventGeneratorBase/GENIE/GENIEHelper.h
+++ b/nugen/EventGeneratorBase/GENIE/GENIEHelper.h
@@ -198,6 +198,7 @@ namespace evgb {
     int                      fGHepPrintLevel;    ///< GHepRecord::SetPrintLevel(), -1=no-print
     std::string              fMixerConfig;       ///< configuration string for genie GFlavorMixerI
     double                   fMixerBaseline;     ///< baseline distance if genie flux can't calculate it
+    bool                     fUseBlenderDist;    ///< get neutrino's travel distance from blender (default: true)
     std::string              fFiducialCut;       ///< configuration for geometry selector
     std::string              fGeomScan;          ///< configuration for geometry scan to determine max pathlengths
     std::string              fMaxPathOutInfo;    ///< output info if writing PathLengthList from GeomScan


### PR DESCRIPTION
resetting the travel distance in fdk2gen when GFluxBlender is used. This commit provides a fcl-configurable, backwards-compatible workaround for the issue described in
https://indico.fnal.gov/event/56265/contributions/251004/attachments/160071/210691/dk2gen_larsoft.pdf. See also the related Redmine issue (https://cdcvs.fnal.gov/redmine/issues/27405) for a backport into the nutools v2_27 series for MicroBooNE.