### PR TITLE
install_source() called without arguments

### DIFF
--- a/nugen/EventGeneratorBase/Modules/CMakeLists.txt
+++ b/nugen/EventGeneratorBase/Modules/CMakeLists.txt
@@ -86,4 +86,4 @@ cet_build_plugin(TestGENIEHelper art::module
 
 install_headers()
 install_fhicl()
-install_source( LIST README )
+install_source()


### PR DESCRIPTION
arguments seemed to be preventing source from actually being installed