### PR TITLE
Additional code for DUNE atmospherics generation

### DIFF
--- a/nugen/EventGeneratorBase/GENIE/GENIE2ART.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GENIE2ART.cxx
@@ -184,10 +184,11 @@ void evgb::FillMCTruth(const genie::EventRecord *record,
                        simb::MCTruth &truth,
                        const std::string & genieVersion,
                        const std::string & genieTune,
-                       bool addGenieVtxTime)
+                       bool addGenieVtxTime,
+                       const std::unordered_map<std::string, std::string> genConfig)
 {
   TLorentzVector vtxOffset(0,0,0,spillTime);
-  FillMCTruth(record,vtxOffset,truth,genieVersion,genieTune,addGenieVtxTime);
+  FillMCTruth(record,vtxOffset,truth,genieVersion,genieTune,addGenieVtxTime, genConfig);
 }
 
 void evgb::FillMCTruth(const genie::EventRecord *record,
@@ -195,7 +196,8 @@ void evgb::FillMCTruth(const genie::EventRecord *record,
                        simb::MCTruth  &truth,
                        const std::string & genieVersion,
                        const std::string & genieTune,
-                       bool addGenieVtxTime)
+                       bool addGenieVtxTime,
+                       const std::unordered_map<std::string, std::string> genConfig)
 {
   // offset vector is assmed to be in (cm,ns) which is MCTruth's units
 
@@ -313,7 +315,9 @@ void evgb::FillMCTruth(const genie::EventRecord *record,
 
   // set the neutrino information in MCTruth
   truth.SetOrigin(simb::kBeamNeutrino);
-  truth.SetGeneratorInfo(simb::Generator_t::kGENIE, genieVersion, {{"tune", genieTune}});
+  std::unordered_map<std::string, std::string> genConfigCopy(genConfig);
+  genConfigCopy.emplace("tune", genieTune);
+  truth.SetGeneratorInfo(simb::Generator_t::kGENIE, genieVersion, genConfigCopy);
 
   // The genie event kinematics are subtle different from the event
   // kinematics that a experimentalist would calculate

--- a/nugen/EventGeneratorBase/GENIE/GENIE2ART.h
+++ b/nugen/EventGeneratorBase/GENIE/GENIE2ART.h
@@ -11,6 +11,7 @@
 #define EVGB_GENIE2ART_H
 
 #include <string>
+#include <unordered_map>
 
 /// GENIE neutrino interaction simulation objects
 namespace genie {
@@ -58,13 +59,15 @@ namespace evgb {
                    simb::MCTruth& mctruth,
                    const std::string & genieVersion="unknown",
                    const std::string & genieTune="unknown",
-                   bool addGenieVtxTime = false);
+                   bool addGenieVtxTime = false,
+                   const std::unordered_map<std::string, std::string> genConfig = {});
   void FillMCTruth(const genie::EventRecord* grec,
                    TLorentzVector& vtxOffset,
                    simb::MCTruth& mctruth,
                    const std::string & genieVersion="unknown",
                    const std::string & genieTune="unknown",
-                   bool addGenieVtxTime = false);
+                   bool addGenieVtxTime = false,
+                   const std::unordered_map<std::string, std::string> genConfig = {});
   void FillGTruth(const genie::EventRecord* grec,
                   simb::GTruth& gtruth);
 

--- a/nugen/EventGeneratorBase/GENIE/GENIEHelper.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GENIEHelper.cxx
@@ -156,6 +156,8 @@
 #include "nugen/EventGeneratorBase/GENIE/EvtTimeShiftFactory.h"
 #include "nugen/EventGeneratorBase/GENIE/EvtTimeShiftI.h"
 
+#include "nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.h"
+
 // nusimdata includes
 #include "nusimdata/SimulationBase/MCTruth.h"
 #include "nusimdata/SimulationBase/MCFlux.h"
@@ -257,11 +259,13 @@ namespace evgb {
     , fRandomTimeOffset  (pset.get< double                   >("RandomTimeOffset", 1.e4) )
     , fSpillTimeConfig   (pset.get< std::string              >("SpillTimeConfig",    "") )
     , fAddGenieVtxTime   (pset.get< bool                     >("AddGenieVtxTime", false) )
+    , fForceApplyFlxWgt  (pset.get< bool                     >("ForceApplyFlxWgt", true) )
     , fGenFlavors        (pset.get< std::vector<int>         >("GenFlavors")             )
     , fAtmoEmin          (pset.get< double                   >("AtmoEmin",          0.1) )
     , fAtmoEmax          (pset.get< double                   >("AtmoEmax",         10.0) )
     , fAtmoRl            (pset.get< double                   >("Rl",               20.0) )
     , fAtmoRt            (pset.get< double                   >("Rt",               20.0) )
+    , fAtmoSpectralIndex (pset.get< double                   >("SpectralIndex",     2.0) )
     , fEnvironment       (pset.get< std::vector<std::string> >("Environment")            )
     , fXSecTable         (pset.get< std::string              >("XSecTable",          "") ) //e.g. "gxspl-FNALsmall.xml"
     , fTuneName          (pset.get< std::string              >("TuneName","${GENIE_XSEC_TUNE}") )
@@ -388,7 +392,7 @@ namespace evgb {
     genie::utils::app_init::RandGen(seedval);
 
     // special things for atmos fluxes
-    if ( fFluxType.find("atmo_") == 0 ) AtmoFluxCheck();
+    if ( fFluxType.find("atmo_") == 0 && fFluxType.find("PowerSpectrum") == std::string::npos) AtmoFluxCheck();
 
     // make the histogram associations
     if ( fFluxType.find("histogram") == 0 ) HistogramFluxCheck();
@@ -410,7 +414,17 @@ namespace evgb {
         << fFunctionalFlux << " E [" << fEmin << ":" << fEmax
         << "] GeV with " << fFunctionalBinning << " bins "
         << "with the following flavors: " << flvlist;
-    } else {
+    } else if (fFluxType.find("PowerSpectrum") != std::string::npos) {
+      mf::LogInfo("GENIEHelper")
+        << "Generating neutrinos using the a power spectrum with Spectral index = "
+        << fAtmoSpectralIndex
+        << ", with the following flavors: " << flvlist
+        << "\nThe energy range is between:  " << fAtmoEmin << " GeV and "
+        << fAtmoEmax << " GeV."
+        << '\n'
+        << "  Generation surface of: (" << fAtmoRl << ","
+        << fAtmoRt << ")";
+    }  else {
 
       // flux methods other than "mono" and "function" require files
       std::string fileliststr;
@@ -731,6 +745,7 @@ namespace evgb {
     if ( tmpFluxType.find("BGLRS")  != std::string::npos ) tmpFluxType = "atmo_BGLRS";
     if ( tmpFluxType.find("HONDA")  != std::string::npos ) tmpFluxType = "atmo_HAKKM";
     if ( tmpFluxType.find("HAKKM")  != std::string::npos ) tmpFluxType = "atmo_HAKKM";
+    if ( tmpFluxType.find("POWER")  != std::string::npos ) tmpFluxType = "atmo_PowerSpectrum";
     // TTree-based fluxes (old "ntuple" is really "numi")
     //    we're allowed to randomize the order here, and squeeze out duplicates
     if ( tmpFluxType.find("simple") != std::string::npos ) tmpFluxType = "tree_simple";
@@ -1263,6 +1278,52 @@ namespace evgb {
       delete input_func;
     } //end if using function beam
 
+    else if(fFluxType.find("PowerSpectrum") != std::string::npos){
+      genie::flux::GPowerSpectrumAtmoFlux *power_flux = new genie::flux::GPowerSpectrumAtmoFlux;
+      power_flux->SetSpectralIndex(fAtmoSpectralIndex);
+      power_flux->SetFlavors(fGenFlavors);
+      power_flux->SetMinEnergy(fAtmoEmin);
+      power_flux->SetMaxEnergy(fAtmoEmax);
+
+      mf::LogInfo("GENIEHelper") << "Setting Emin=" << fEmin << " ; Emax=" << fEmax;
+
+      for ( size_t j = 0; j < fGenFlavors.size(); ++j ) {
+        int         flavor  = fGenFlavors[j];
+        std::string flxfile = fSelectedFluxFiles[j];
+        power_flux->AddFluxFile(flavor,flxfile); // pre-R-2_11_0 was SetFluxFile()
+      }
+
+
+      if ( fFluxRotation ){
+        power_flux->SetUserCoordSystem(*fFluxRotation);
+        std::ostringstream atmoCfgText;
+        const int w=13, p=6;
+        auto old_p = atmoCfgText.precision(p);
+        atmoCfgText << "\n UserCoordSystem rotation:\n"
+                    << "  [ "
+                    << std::setw(w) << fFluxRotation->XX() << " "
+                    << std::setw(w) << fFluxRotation->XY() << " "
+                    << std::setw(w) << fFluxRotation->XZ() << " ]\n"
+                    << "  [ "
+                    << std::setw(w) << fFluxRotation->YX() << " "
+                    << std::setw(w) << fFluxRotation->YY() << " "
+                    << std::setw(w) << fFluxRotation->YZ() << " ]\n"
+                    << "  [ "
+                    << std::setw(w) << fFluxRotation->ZX() << " "
+                    << std::setw(w) << fFluxRotation->ZY() << " "
+                    << std::setw(w) << fFluxRotation->ZZ() << " ]\n";
+        atmoCfgText.precision(old_p);
+        mf::LogInfo("GENIEHelper") << atmoCfgText.str();
+      }
+
+      power_flux->LoadFluxData();
+
+      // configure flux generation surface:
+      power_flux->SetRadii(fAtmoRl, fAtmoRt);
+
+      fFluxD = power_flux;//dynamic_cast<genie::GFluxI *>(atmo_flux_driver);
+    }
+
     // Using the atmospheric fluxes
     else if ( fFluxType.find("atmo_") == 0 ) {
 
@@ -1562,12 +1623,25 @@ namespace evgb {
       // discrepency between AtmoFluxDriver(/m2) and Generate(/cm2)
       // and it need to be normalized by the generation surface area since
       // it's not taken into accoutn in the flux driver
-      fTotalExposure =
-        (dynamic_cast<genie::flux::GAtmoFlux *>(fFluxD)->NFluxNeutrinos())
-        * 1.0e4 / (TMath::Pi() * fAtmoRt*fAtmoRt);
 
-      mf::LogInfo("GENIEHelper")
-        << "===> Atmo EXPOSURE = " << fTotalExposure << " seconds";
+      long int nNeutrinos;
+
+      if(fFluxType.find("PowerSpectrum") != std::string::npos){
+        nNeutrinos = dynamic_cast<genie::flux::GPowerSpectrumAtmoFlux *>(fFluxD)->NFluxNeutrinos();
+        fTotalExposure = nNeutrinos/fGenFlavors.size();
+        mf::LogInfo("GENIEHelper")
+        << "===> Atmo Ngen/Nflavours = " << fTotalExposure;
+      }
+      else{
+        nNeutrinos = dynamic_cast<genie::flux::GAtmoFlux *>(fFluxD)->NFluxNeutrinos();
+        fTotalExposure = nNeutrinos * 1.0e4 / (TMath::Pi() * fAtmoRt*fAtmoRt);
+        mf::LogInfo("GENIEHelper")
+        << "===> Atmo EXPOSURE = " << fTotalExposure << " seconds.";
+      }
+
+      
+
+      
 
     } else {
       fTotalExposure += fSpillExposure;
@@ -1593,6 +1667,21 @@ namespace evgb {
     if (fUseHelperRndGen4GENIE) gRandom = fHelperRandom;
 
     fGenieEventRecord = fDriver->GenerateEvent();
+
+    if (fForceApplyFlxWgt) {
+      //const issue:  double flxweight = fDriver->FluxDriver().Weight();
+      //genie::GFluxI& flx = const_cast<genie::GFluxI&>(fDriver->FluxDriver());
+      //double flxweight = flx.Weight();
+      // use the flux driver handle we already have, rather than fetch const one
+      //   from the GMCJDriver fDriver
+      double flxweight = fFluxD->Weight();
+      double curweight = fGenieEventRecord->Weight();
+      double probscale = fDriver->GlobProbScale();
+      mf::LogInfo("GENIEHelper") << "flxweight: " << flxweight << " ; "
+                                 << "curweight: " << curweight << " ; "
+                                 << "probscale: " << probscale;
+      fGenieEventRecord->SetWeight(flxweight*curweight*probscale);
+    }
 
     if (fUseHelperRndGen4GENIE) gRandom = old_gRandom;
 
@@ -1628,6 +1717,12 @@ namespace evgb {
     }
     // mf::LogInfo("GENIEHelper") << "TimeShifter adding " << timeoffset;
     double spilltime  = fGlobalTimeOffset + timeoffset;
+
+    std::unordered_map<std::string, std::string> genConfig;
+
+    if(fFluxType.find("PowerSpectrum") != std::string::npos){
+      genConfig.emplace("SpectralIndex", std::to_string(fAtmoSpectralIndex));
+    }
 
     evgb::FillMCTruth(fGenieEventRecord, spilltime, truth,
                       __GENIE_RELEASE__, fTuneName, fAddGenieVtxTime );
@@ -1674,6 +1769,7 @@ namespace evgb {
     }
     else if ( fFluxType.find("atmo_FLUKA")  == 0 ||
               fFluxType.find("atmo_BARTOL") == 0 ||
+              fFluxType.find("atmo_PowerSpectrum") == 0 ||
               fFluxType.find("atmo_BGLRS")  == 0 ||
               fFluxType.find("atmo_HAKKM")  == 0 ||
               fFluxType.find("atmo_HONDA")  == 0    ) {

--- a/nugen/EventGeneratorBase/GENIE/GENIEHelper.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GENIEHelper.cxx
@@ -1291,7 +1291,7 @@ namespace evgb {
       for ( size_t j = 0; j < fGenFlavors.size(); ++j ) {
         int         flavor  = fGenFlavors[j];
         std::string flxfile = fSelectedFluxFiles[j];
-        power_flux->AddFluxFile(flavor,flxfile); // pre-R-2_11_0 was SetFluxFile()
+        power_flux->AddFluxFile(flavor,flxfile);
       }
 
 
@@ -1322,7 +1322,7 @@ namespace evgb {
       // configure flux generation surface:
       power_flux->SetRadii(fAtmoRl, fAtmoRt);
 
-      fFluxD = power_flux;//dynamic_cast<genie::GFluxI *>(atmo_flux_driver);
+      fFluxD = power_flux;
     }
 
     // Using the atmospheric fluxes
@@ -1629,9 +1629,9 @@ namespace evgb {
 
       if(fFluxType.find("PowerSpectrum") != std::string::npos){
         nNeutrinos = dynamic_cast<genie::flux::GPowerSpectrumAtmoFlux *>(fFluxD)->NFluxNeutrinos();
-        fTotalExposure = nNeutrinos/fGenFlavors.size();
+        fTotalExposure = nNeutrinos/fGenFlavors.size()/fDriver->GlobProbScale();
         mf::LogInfo("GENIEHelper")
-        << "===> Atmo Ngen/Nflavours = " << fTotalExposure;
+        << "===> Atmo Pscale*Ngen/Nflavours = " << fTotalExposure;
       }
       else{
         nNeutrinos = dynamic_cast<genie::flux::GAtmoFlux *>(fFluxD)->NFluxNeutrinos();
@@ -1677,11 +1677,7 @@ namespace evgb {
       //   from the GMCJDriver fDriver
       double flxweight = fFluxD->Weight();
       double curweight = fGenieEventRecord->Weight();
-      double probscale = fDriver->GlobProbScale();
-      mf::LogInfo("GENIEHelper") << "flxweight: " << flxweight << " ; "
-                                 << "curweight: " << curweight << " ; "
-                                 << "probscale: " << probscale;
-      fGenieEventRecord->SetWeight(flxweight*curweight*probscale);
+      fGenieEventRecord->SetWeight(flxweight*curweight);
     }
 
     if (fUseHelperRndGen4GENIE) gRandom = old_gRandom;

--- a/nugen/EventGeneratorBase/GENIE/GENIEHelper.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GENIEHelper.cxx
@@ -393,7 +393,7 @@ namespace evgb {
     genie::utils::app_init::RandGen(seedval);
 
     // special things for atmos fluxes
-    if ( fFluxType.find("atmo_") == 0 && fFluxType.find("PowerSpectrum") == std::string::npos) AtmoFluxCheck();
+    if ( fFluxType.find("atmo_") == 0 ) AtmoFluxCheck();
 
     // make the histogram associations
     if ( fFluxType.find("histogram") == 0 ) HistogramFluxCheck();
@@ -819,6 +819,9 @@ namespace evgb {
     else if (fFluxType.find("HONDA") != std::string::npos ||
              fFluxType.find("HAKKM") != std::string::npos    ){
       atmofluxinfo << "  The fluxes are from HONDA/HAKKM";
+    }
+    else if (fFluxType.find("PowerSpectrum") != std::string::npos){
+      atmofluxinfo << "  The fluxes are interpolated HONDA";
     }
     else {
       mf::LogInfo("GENIEHelper")

--- a/nugen/EventGeneratorBase/GENIE/GENIEHelper.h
+++ b/nugen/EventGeneratorBase/GENIE/GENIEHelper.h
@@ -181,6 +181,7 @@ namespace evgb {
     double                   fRandomTimeOffset;  ///< additional random time shift (ns) added to every particle time
     std::string              fSpillTimeConfig;   ///< alternative to flat spill distribution
     bool                     fAddGenieVtxTime;   ///< incorporate time from flux window to interaction point and (possibily) proton-on-target to flux window
+    bool                     fForceApplyFlxWgt;  ///< apply GFluxI::Weight() before returning event
 
     std::vector<int>         fGenFlavors;        ///< pdg codes for flavors to generate
     double                   fAtmoEmin;          ///< atmo: Minimum energy of neutrinos in GeV
@@ -188,6 +189,8 @@ namespace evgb {
     double                   fAtmoRl;            ///< atmo: radius of the sphere on where the neutrinos are generated
     double                   fAtmoRt;            ///< atmo: radius of the transvere (perpendicular) area on the sphere
                                                  ///< where the neutrinos are generated
+    double                   fAtmoSpectralIndex; ///< atmo: Spectral index for power spectrum generation
+    
     std::vector<std::string> fEnvironment;       ///< environmental variables and settings used by genie
     std::string              fXSecTable;         ///< cross section file (was $GSPLOAD)
     std::string              fTuneName;          ///< GENIE R-3 Tune name (defines model configuration)

--- a/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.cxx
@@ -16,6 +16,7 @@
 #include "Framework/ParticleData/PDGLibrary.h"
 #include "TFile.h"
 #include "TH3D.h"
+#include "TH2.h"
 
 FLUXDRIVERREG4(genie,flux,GPowerSpectrumAtmoFlux,genie::flux::GPowerSpectrumAtmoFlux)
 
@@ -525,13 +526,12 @@ double GPowerSpectrumAtmoFlux::GetFlux(int flavour, double energy, double costh,
 
   if(!flux_hist) return 0.0;
 
-  Int_t e_bin = flux_hist->GetXaxis()->FindBin(energy);
-  Int_t c_bin = flux_hist->GetYaxis()->FindBin(costh);
-  Int_t p_bin = flux_hist->GetZaxis()->FindBin(phi);
-
-  Double_t flux = flux_hist->GetBinContent(e_bin,c_bin,p_bin);
-
-  return flux;
+  if(flux_hist->GetZaxis()->GetNbins() == 1){ //no binning in phi, bilinear interpolation only
+	return static_cast<TH2*>(flux_hist->Project3D("xy"))->Interpolate(energy, costh);
+  }
+  else {
+	return flux_hist->Interpolate(energy, costh, phi);
+  }
 }
 
 //_________________________________________________________________________

--- a/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.cxx
@@ -387,6 +387,10 @@ bool GPowerSpectrumAtmoFlux::FillFluxHisto(int nu_pdg, string filename){
 
 	fRawFluxHistoMap.insert(std::make_pair(nu_pdg, h));
 
+	TH2D* h2 = static_cast<TH2D*>(h->Project3D("yx"));
+
+	fRawFluxHistoMap2D.insert(std::make_pair(nu_pdg, h2));
+
 	return true;
 }
 
@@ -526,8 +530,9 @@ double GPowerSpectrumAtmoFlux::GetFlux(int flavour, double energy, double costh,
 
   if(!flux_hist) return 0.0;
 
-  if(flux_hist->GetZaxis()->GetNbins() == 1){ //no binning in phi, bilinear interpolation only
-	return static_cast<TH2*>(flux_hist->Project3D("xy"))->Interpolate(energy, costh);
+  if(flux_hist->GetZaxis()->GetNbins() == 1){ //no binning in phi, bilinear interpolation only so using the 2D hist
+	TH2D* h2 = fRawFluxHistoMap2D[it->first];
+	return h2->Interpolate(energy, costh);
   }
   else {
 	return flux_hist->Interpolate(energy, costh, phi);

--- a/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.cxx
@@ -1,0 +1,561 @@
+#include <cmath>
+#include <fstream>
+
+#include <TMath.h>
+#include <TLorentzVector.h>
+
+#include "nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.h"
+#include "GENIE/Framework/Numerical/RandomGen.h"
+#include "GENIE/Framework/Conventions/Constants.h"
+#include "GENIE/Framework/Utils/PrintUtils.h"
+#include "GENIE/Tools/Flux/GFluxDriverFactory.h"
+#include "GENIE/Framework/Messenger/Messenger.h"
+#include "Framework/ParticleData/PDGCodeList.h"
+#include "Framework/ParticleData/PDGCodes.h"
+#include "Framework/ParticleData/PDGUtils.h"
+#include "Framework/ParticleData/PDGLibrary.h"
+#include "TFile.h"
+#include "TH3D.h"
+
+FLUXDRIVERREG4(genie,flux,GPowerSpectrumAtmoFlux,genie::flux::GPowerSpectrumAtmoFlux)
+
+using namespace genie;
+using namespace genie::flux;
+using namespace genie::constants;
+
+GPowerSpectrumAtmoFlux::GPowerSpectrumAtmoFlux()
+{
+	LOG("Flux", pNOTICE)
+	<< "Instantiating the GENIE Power Spectrum atmospheric neutrino flux driver";
+	this->Initialize();
+}
+
+//________________________________________________________________________________________
+
+GPowerSpectrumAtmoFlux::~GPowerSpectrumAtmoFlux()
+{
+
+}
+
+
+//__________________________________________________________________________________________________
+
+const PDGCodeList &GPowerSpectrumAtmoFlux::FluxParticles (void)
+{
+	return *fPdgCList;
+}
+
+//_________________________________________________________________
+
+double GPowerSpectrumAtmoFlux::MaxEnergy(void)
+{
+  return fMaxEvCut;
+}
+
+//__________________________________________________________________
+
+double GPowerSpectrumAtmoFlux::MinEnergy(void)
+{
+  return fMinEvCut;
+}
+
+//_________________________________________________________________________
+
+bool GPowerSpectrumAtmoFlux::GenerateNext(void)
+{
+	// Reset previously generated neutrino code / 4-p / 4-x
+	this->ResetSelection();
+
+	// Get a RandomGen instance
+	RandomGen * rnd = RandomGen::Instance();
+
+	// Generate (Ev, costheta, phi)
+	double Ev       = 0.;
+	double costheta = 0.;
+	double phi      = 0;
+	double weight   = 0;
+	int    nu_pdg   = 0;
+
+	// generate events according to a power law spectrum,
+	// then weight events by inverse power law
+	// (note: cannot use index alpha=1)
+	double alpha = fSpectralIndex;
+
+	double emin = TMath::Power(this->MinEnergy(),1.0-alpha);
+	double emax = TMath::Power(this->MaxEnergy(),1.0-alpha);
+	Ev          = TMath::Power(emin+(emax-emin)*rnd->RndFlux().Rndm(),1.0/(1.0-alpha));
+	costheta    = -1+2*rnd->RndFlux().Rndm();
+	phi         = 2.*kPi* rnd->RndFlux().Rndm();
+
+	unsigned int nnu = fPdgCList->size();
+	unsigned int inu = rnd->RndFlux().Integer(nnu);
+	nu_pdg   = (*fPdgCList)[inu];
+	weight = this->ComputeWeight(nu_pdg, Ev, costheta, phi);
+
+	// Compute etc trigonometric numbers
+	double sintheta  = TMath::Sqrt(1-costheta*costheta);
+	double cosphi    = TMath::Cos(phi);
+	double sinphi    = TMath::Sin(phi);
+
+	// Set the neutrino pdg code
+	fgPdgC = nu_pdg;
+
+	// Set the neutrino weight
+	fWeight = weight;
+
+	// Compute the neutrino momentum
+	// The `-1' means it is directed towards the detector.
+	double pz = -1.* Ev * costheta;
+	double py = -1.* Ev * sintheta * sinphi;
+	double px = -1.* Ev * sintheta * cosphi;
+
+	// Default vertex is at the origin
+	double z = 0.0;
+	double y = 0.0;
+	double x = 0.0;
+
+	// Shift the neutrino position onto the flux generation surface.
+	// The position is computed at the surface of a sphere with R=fRl
+	// at the topocentric horizontal (THZ) coordinate system.
+	if( fRl>0.0 ){
+	z += fRl * costheta;
+	y += fRl * sintheta * sinphi;
+	x += fRl * sintheta * cosphi;
+	}
+
+	// Apply user-defined rotation from THZ -> user-defined topocentric
+	// coordinate system.
+	if( !fRotTHz2User.IsIdentity() )
+	{
+	TVector3 tx3(x, y, z );
+	TVector3 tp3(px,py,pz);
+
+	tx3 = fRotTHz2User * tx3;
+	tp3 = fRotTHz2User * tp3;
+
+	x  = tx3.X();
+	y  = tx3.Y();
+	z  = tx3.Z();
+	px = tp3.X();
+	py = tp3.Y();
+	pz = tp3.Z();
+	}
+
+	// If the position is left as is, then all generated neutrinos
+	// would point towards the origin.
+	// Displace the position randomly on the surface that is
+	// perpendicular to the selected point P(xo,yo,zo) on the sphere
+	if( fRt>0.0 ){
+	TVector3 vec(x,y,z);               // vector towards selected point
+	TVector3 dvec1 = vec.Orthogonal(); // orthogonal vector
+	TVector3 dvec2 = dvec1;            // second orthogonal vector
+	dvec2.Rotate(-kPi/2.0,vec);        // rotate second vector by 90deg,
+	                                   // now forming a new orthogonal cartesian coordinate system
+	double psi = 2.*kPi* rnd->RndFlux().Rndm(); // rndm angle [0,2pi]
+	double random = rnd->RndFlux().Rndm();      // rndm number  [0,1]
+	dvec1.SetMag(TMath::Sqrt(random)*fRt*TMath::Cos(psi));
+	dvec2.SetMag(TMath::Sqrt(random)*fRt*TMath::Sin(psi));
+	x += dvec1.X() + dvec2.X();
+	y += dvec1.Y() + dvec2.Y();
+	z += dvec1.Z() + dvec2.Z();
+	}
+
+	// Set the neutrino momentum and position 4-vectors with values
+	// calculated at previous steps.
+	fgP4.SetPxPyPzE(px, py, pz, Ev);
+	fgX4.SetXYZT   (x,  y,  z,  0.);
+
+	// Increment flux neutrino counter used for sample normalization purposes.
+	fNNeutrinos++;
+
+	// Report and exit
+	LOG("Flux", pINFO)
+	   << "Generated neutrino: "
+	   << "\n pdg-code: " << fgPdgC
+	   << "\n p4: " << utils::print::P4AsShortString(&fgP4)
+	   << "\n x4: " << utils::print::X4AsString(&fgX4);
+
+	return true;
+}
+
+//________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::ResetSelection(void)
+{
+// initializing running neutrino pdg-code, 4-position, 4-momentum
+
+  fgPdgC = 0;
+  fgP4.SetPxPyPzE (0.,0.,0.,0.);
+  fgX4.SetXYZT    (0.,0.,0.,0.);
+  fWeight = 0;
+}
+
+//________________________________________________________________
+
+int GPowerSpectrumAtmoFlux::PdgCode(void)
+{
+	return fgPdgC;
+}
+
+//________________________________________________________________
+
+double GPowerSpectrumAtmoFlux::Weight(void)
+{
+	return fWeight;
+}
+
+//________________________________________________________________
+
+const TLorentzVector& GPowerSpectrumAtmoFlux::Momentum(void)
+{
+	return fgP4;
+}
+
+//________________________________________________________________
+
+const TLorentzVector& GPowerSpectrumAtmoFlux::Position(void)
+{
+	return fgX4;
+}
+
+//________________________________________________________________
+
+bool GPowerSpectrumAtmoFlux::End(void)
+{
+	return false;
+}
+
+//________________________________________________________________
+
+long int GPowerSpectrumAtmoFlux::Index(void)
+{
+	return -1;
+}
+
+//________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::ResetNFluxNeutrinos(void)
+{
+	fNNeutrinos = 0;
+}
+
+//________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::Clear(Option_t * opt)
+{
+	LOG("Flux", pWARN) << "GPowerSpectrumAtmoFlux::Clear(" << opt << ") called";
+	this->ResetNFluxNeutrinos();
+}
+
+//________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::GenerateWeighted(bool gen_weighted)
+{
+// Dummy clear method needed to conform to GFluxI interface
+//
+  LOG("Flux", pERROR) <<
+  "The neutrinos are always generated weighted with this implementation!! GenerateWeighted method not implemented.";
+}
+
+//______________________________________________________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::SetSpectralIndex(double index)
+{
+	if( index != 1.0 ){
+		fSpectralIndex = index;
+	}
+	else {
+		LOG("Flux", pWARN) << "Warning: cannot use a spectral index of unity";
+	}
+	LOG("Flux", pNOTICE) << "Using Spectral Index = " << index;
+}
+
+//____________________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::SetUserCoordSystem(TRotation &rotation)
+{
+  fRotTHz2User = rotation;
+}
+
+//__________________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::Initialize(void)
+{
+	LOG("Flux", pNOTICE) << "Initializing power spectrum atmospheric flux driver";
+
+	bool allow_dup = false;
+	fPdgCList = new PDGCodeList(allow_dup);
+
+	fSpectralIndex = 2.0;
+
+	fMinEvCut = 0.01;
+	fMaxEvCut = 9999999999;
+
+	// Default radii
+	fRl = 0.0;
+	fRt = 0.0;
+	fAgen = 0.0;
+
+	// Default detector coord system: Topocentric Horizontal Coordinate system
+	fRotTHz2User.SetToIdentity();
+
+	// Reset `current' selected flux neutrino
+	this->ResetSelection();
+
+	// Reset number of neutrinos thrown so far
+	fNNeutrinos = 0;
+
+	// Init the global gen weight
+	this->InitializeWeight();
+}
+
+//_________________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::SetRadii(double Rlongitudinal, double Rtransverse)
+{
+  LOG ("Flux", pNOTICE) << "Setting R[longitudinal] = " << Rlongitudinal;
+  LOG ("Flux", pNOTICE) << "Setting R[transverse]   = " << Rtransverse;
+
+  fRl = Rlongitudinal;
+  fRt = Rtransverse;
+
+  fAgen = kPi*fRt*fRt;
+}
+
+//________________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::SetFlavors(std::vector<int> flavors)
+{
+	fPdgCList->clear();
+	for(int flavor : flavors){
+		fPdgCList->push_back(flavor);
+	}
+}
+
+//________________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::CleanUp(void)
+{
+	LOG("Flux", pNOTICE) << "Cleaning up...";
+
+	if (fPdgCList) delete fPdgCList;
+}
+
+//________________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::SetMinEnergy(double Emin)
+{
+	if(Emin > 0){
+		fMinEvCut = Emin;
+	}
+}
+
+//_________________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::SetMaxEnergy(double Emax){
+	fMaxEvCut = Emax;
+}
+
+//_________________________________________________________________________________
+
+long int GPowerSpectrumAtmoFlux::NFluxNeutrinos(void) const
+{
+  return fNNeutrinos;
+}
+
+//_________________________________________________________________________________
+
+bool GPowerSpectrumAtmoFlux::FillFluxHisto(int nu_pdg, string filename){
+	LOG("Flux", pNOTICE)
+    << "Loading fine grained flux for neutrino: " << nu_pdg
+    << " from file: " << filename;
+
+	TH3D* histo = nullptr;
+
+	TFile *f = new TFile(filename.c_str(), "READ");
+	f->GetObject("flux", histo);
+
+	if(!histo) {
+		LOG("Flux", pERROR) << "Null flux histogram!";
+		f->Close();
+		return false;
+	}
+
+	TH3D* h = static_cast<TH3D*>(histo->Clone());
+	f->Close();
+
+	fRawFluxHistoMap.insert(std::make_pair(nu_pdg, h));
+
+	return true;
+}
+
+//_________________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::AddFluxFile(int nu_pdg, string filename)
+{
+  // Check file exists
+  std::ifstream f(filename.c_str());
+  if (!f.good()) {
+    LOG("Flux", pFATAL) << "Flux file does not exist "<<filename;
+    exit(-1);
+  }
+  if ( pdg::IsNeutrino(nu_pdg) || pdg::IsAntiNeutrino(nu_pdg) ) {
+    fFluxFlavour.push_back(nu_pdg);
+    fFluxFile.push_back(filename);
+  } else {
+    LOG ("Flux", pWARN)
+      << "Input particle code: " << nu_pdg << " not a neutrino!";
+  }
+}
+
+//_________________________________________________________________________________
+
+bool GPowerSpectrumAtmoFlux::LoadFluxData(void)
+{
+  LOG("Flux", pNOTICE)
+        << "Loading atmospheric neutrino flux simulation data";
+
+  fFluxHistoMap.clear();
+  fPdgCList->clear();
+
+  bool loading_status = true;
+
+  for( unsigned int n=0; n<fFluxFlavour.size(); n++ ){
+    int nu_pdg      = fFluxFlavour.at(n);
+    string filename = fFluxFile.at(n);
+    string pname = PDGLibrary::Instance()->Find(nu_pdg)->GetName();
+
+    LOG("Flux", pNOTICE) << "Loading data for: " << pname;
+
+    bool loaded = this->FillFluxHisto(nu_pdg, filename);
+
+    loading_status = loading_status && loaded;
+
+    if (!loaded) {
+        LOG("Flux", pERROR)
+          << "Error loading atmospheric neutrino flux simulation data from " << filename;
+        break;
+    }
+  }
+
+  if(loading_status) {
+    map<int,TH3D*>::iterator hist_iter = fRawFluxHistoMap.begin();
+    for ( ; hist_iter != fRawFluxHistoMap.end(); ++hist_iter) {
+      int   nu_pdg = hist_iter->first;
+      TH3D* hist   = hist_iter->second;
+
+      TH3D* hnorm = this->CreateNormalisedFluxHisto( hist );
+      fFluxHistoMap.insert( map<int,TH3D*>::value_type(nu_pdg,hnorm) );
+      fPdgCList->push_back(nu_pdg);
+    }
+
+    LOG("Flux", pNOTICE)
+          << "Atmospheric neutrino flux simulation data loaded!";
+    return true;
+  }
+
+  LOG("Flux", pERROR)
+    << "Error loading atmospheric neutrino flux simulation data";
+  return false;
+}
+
+//________________________________________________________________________
+
+TH3D* GPowerSpectrumAtmoFlux::CreateNormalisedFluxHisto(TH3D* hist)
+{
+// return integrated flux
+
+  // sanity check
+  if(!hist) return 0;
+
+  // make new histogram name
+  TString histname = hist->GetName();
+  histname.Append("_IntegratedFlux");
+
+  // make new histogram
+  TH3D* hist_intg = (TH3D*)(hist->Clone(histname.Data()));
+  hist_intg->Reset();
+
+  // integrate flux in each bin
+  Double_t dN_dEdS = 0.0;
+  Double_t dS = 0.0;
+  Double_t dE = 0.0;
+  Double_t dN = 0.0;
+
+  for(Int_t e_bin = 1; e_bin <= hist->GetXaxis()->GetNbins(); e_bin++)
+  {
+    for(Int_t c_bin = 1; c_bin <= hist->GetYaxis()->GetNbins(); c_bin++)
+    {
+      for(Int_t p_bin = 1; p_bin <= hist->GetZaxis()->GetNbins(); p_bin++)
+      {
+         dN_dEdS = hist->GetBinContent(e_bin,c_bin,p_bin);
+
+         dE = hist->GetXaxis()->GetBinUpEdge(e_bin)
+            - hist->GetXaxis()->GetBinLowEdge(e_bin);
+
+         dS = ( hist->GetZaxis()->GetBinUpEdge(p_bin)
+              - hist->GetZaxis()->GetBinLowEdge(p_bin)  )
+            * ( hist->GetYaxis()->GetBinUpEdge(c_bin)
+              - hist->GetYaxis()->GetBinLowEdge(c_bin) );
+
+         dN = dN_dEdS*dE*dS;
+
+         hist_intg->SetBinContent(e_bin,c_bin,p_bin,dN);
+      }
+    }
+  }
+
+  return hist_intg;
+}
+
+
+//_________________________________________________________________________
+
+double GPowerSpectrumAtmoFlux::GetFlux(int flavour, double energy, double costh, double phi)
+{
+  //TODO: ADD SOME INTERPOLATION
+  TH3D* flux_hist = nullptr;
+  std::map<int,TH3D*>::iterator it = fRawFluxHistoMap.find(flavour);
+  if(it != fRawFluxHistoMap.end())
+  {
+    flux_hist = it->second;
+  }
+
+  LOG("Flux", pERROR) << "flux_hist: " << flux_hist;
+
+  if(!flux_hist) return 0.0;
+
+  Int_t e_bin = flux_hist->GetXaxis()->FindBin(energy);
+  Int_t c_bin = flux_hist->GetYaxis()->FindBin(costh);
+  Int_t p_bin = flux_hist->GetZaxis()->FindBin(phi);
+
+  Double_t flux = flux_hist->GetBinContent(e_bin,c_bin,p_bin);
+
+  return flux;
+}
+
+//_________________________________________________________________________
+
+double GPowerSpectrumAtmoFlux::ComputeWeight(int flavour, double energy, double costh, double phi)
+{
+  double flux = this->GetFlux(flavour, energy, costh, phi);
+
+  return flux*fAgen*fGlobalGenWeight*pow(energy, fSpectralIndex);
+}
+
+//_________________________________________________________________________
+
+void GPowerSpectrumAtmoFlux::InitializeWeight()
+{
+	LOG("Flux", pNOTICE) << "Initializing generation weight";
+
+	double IE = 1.;
+
+	if(fSpectralIndex!=1){
+		IE = (pow(fMaxEvCut,(1.-fSpectralIndex))-pow(fMinEvCut,(1.-fSpectralIndex)))/(1.-fSpectralIndex);
+	}
+
+	double ITheta = 4*kPi;
+
+	fGlobalGenWeight=IE*ITheta;
+}

--- a/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.h
+++ b/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.h
@@ -20,6 +20,7 @@
 
 #include "GENIE/Tools/Flux/GAtmoFlux.h"
 #include "GENIE/Framework/ParticleData/PDGCodeList.h"
+#include "TH2D.h"
 
 namespace genie {
 namespace flux {
@@ -77,6 +78,7 @@ private:
     vector<string> fFluxFile; ///< input flux file for each neutrino species
 	map<int, TH3D*> fFluxHistoMap; ///< flux = f(Ev,cos8,phi) for each neutrino species
   	map<int, TH3D*> fRawFluxHistoMap; ///< flux = f(Ev,cos8,phi) for each neutrino species
+  	map<int, TH2D*> fRawFluxHistoMap2D; ///< flux = f(Ev,cos8) for each neutrino species
 
 	bool FillFluxHisto(int nu_pdg, string filename);
 	void AddAllFluxes(void);

--- a/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.h
+++ b/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.h
@@ -76,7 +76,6 @@ private:
 	long int fNNeutrinos; ///< number of flux neutrinos thrown so far
 	vector<int> fFluxFlavour; ///< input flux file for each neutrino species
     vector<string> fFluxFile; ///< input flux file for each neutrino species
-	map<int, TH3D*> fFluxHistoMap; ///< flux = f(Ev,cos8,phi) for each neutrino species
   	map<int, TH3D*> fRawFluxHistoMap; ///< flux = f(Ev,cos8,phi) for each neutrino species
   	map<int, TH2D*> fRawFluxHistoMap2D; ///< flux = f(Ev,cos8) for each neutrino species
 

--- a/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.h
+++ b/nugen/EventGeneratorBase/GENIE/GPowerSpectrumAtmoFlux.h
@@ -1,0 +1,91 @@
+//____________________________________________________________________________
+/*!
+
+\class   genie::flux::GPowerSpectrumAtmoFlux
+
+\brief   A driver for a power spectrum atmospheric neutrino flux.
+		 Elements extensively reused from GAtmoFlux.
+
+\author  Pierre Granger <granger@apc.in2p3.fr>
+         APC (CNRS)
+
+\created December 16, 2022
+
+*/
+//____________________________________________________________________________
+
+#pragma once
+
+#include <TLorentzVector.h>
+
+#include "GENIE/Tools/Flux/GAtmoFlux.h"
+#include "GENIE/Framework/ParticleData/PDGCodeList.h"
+
+namespace genie {
+namespace flux {
+
+class GPowerSpectrumAtmoFlux: public GFluxI {
+public:
+	GPowerSpectrumAtmoFlux();
+	~GPowerSpectrumAtmoFlux();
+
+	const PDGCodeList &FluxParticles(void) override;  ///< declare list of flux neutrinos that can be generated (for init. purposes)
+	double MaxEnergy(void) override; ///< declare the max flux neutrino energy that can be generated (for init. purposes)
+	bool GenerateNext(void) override; ///< generate the next flux neutrino (return false in err)
+	int PdgCode(void) override; ///< returns the flux neutrino pdg code
+	double Weight(void) override; ///< returns the flux neutrino weight (if any)
+	const TLorentzVector& Momentum(void) override; ///< returns the flux neutrino 4-momentum
+	const TLorentzVector& Position(void) override; ///< returns the flux neutrino 4-position (note: expect SI rather than physical units)
+	bool End(void) override; ///< true if no more flux nu's can be thrown (eg reaching end of beam sim ntuples)
+	long int Index(void) override; ///< returns corresponding index for current flux neutrino (e.g. for a flux ntuple returns the current entry number)
+	void Clear(Option_t *opt) override; ///< reset state variables based on opt
+	void GenerateWeighted(bool gen_weighted) override; ///< set whether to generate weighted or unweighted neutrinos
+
+	double MinEnergy(void);
+	void SetSpectralIndex(double index);
+	void SetUserCoordSystem(TRotation &rotation);
+	void SetRadii(double Rlongitudinal, double Rtransverse);
+	void SetFlavors(std::vector<int> flavors);
+	void SetMinEnergy(double Emin);
+	void SetMaxEnergy(double Emax);
+	long int NFluxNeutrinos(void) const;
+	void ResetNFluxNeutrinos(void);
+	void AddFluxFile(int neutrino_pdg, string filename);
+	bool LoadFluxData(void);
+
+	double GetFlux(int flavour, double energy, double costh, double phi);
+	double ComputeWeight(int flavour, double energy, double costh, double phi);
+	void InitializeWeight();
+
+
+private:
+	PDGCodeList *fPdgCList; ///< input list of neutrino pdg-codes
+	double fMaxEvCut; ///< user-defined cut: maximum energy
+	double fMinEvCut; ///< user-defined cut: minimum energy
+	int fgPdgC; ///< current generated nu pdg-code
+	TLorentzVector fgP4; ///< current generated nu 4-momentum
+	TLorentzVector fgX4; ///< current generated nu 4-position
+	double fWeight; ///< current generated nu weight
+	double fSpectralIndex; ///< power law function
+	double fRl; ///< defining flux neutrino generation surface: longitudinal radius
+	double fRt; ///< defining flux neutrino generation surface: transverse radius
+	double fGlobalGenWeight; ///< global generation weight to apply to all events
+	double fAgen; ///< current generation area
+	TRotation fRotTHz2User; ///< coord. system rotation: THZ -> Topocentric user-defined
+	long int fNNeutrinos; ///< number of flux neutrinos thrown so far
+	vector<int> fFluxFlavour; ///< input flux file for each neutrino species
+    vector<string> fFluxFile; ///< input flux file for each neutrino species
+	map<int, TH3D*> fFluxHistoMap; ///< flux = f(Ev,cos8,phi) for each neutrino species
+  	map<int, TH3D*> fRawFluxHistoMap; ///< flux = f(Ev,cos8,phi) for each neutrino species
+
+	bool FillFluxHisto(int nu_pdg, string filename);
+	void AddAllFluxes(void);
+	TH3D* CreateNormalisedFluxHisto( TH3D* hist);  // normalise flux files
+	void ResetSelection(void);
+	void Initialize(void);
+	void CleanUp(void);
+};
+
+
+} // flux namespace
+} // genie namespace


### PR DESCRIPTION
This pull request aims at pushing code into nugen to allow for DUNE atmospherics sample generation to be performed in a modified way with respect to the existing possibilities.
The main changes are the following:

- Addition of a new GENIE flux driver, `GPowerSpectrumAtmoFlux`, largely based on `GAtmoFlux` but not inheriting from it for technical reasons. The event generation is made according to a power law and by weighting the events according to a flux. This flux driver features:
  - Importation of TH3 ($E$, $\cos{\theta}$, $\phi$) fluxes
  - Trilinear interpolation of the flux based on the provided bins
  - Addition of normalization factors
- Additions to `GENIEHelper` to:
  - Use this new driver
  - Force the use of GENIE weight through the `fForceApplyFlxWgt` flag
  - Set `fTotalExposure` with an "atmospherics exposure" later used for the whole normalization of the generation sample.

This generation framework has been presented and approved at the High Energy Physics WG of DUNE (https://indico.fnal.gov/event/58858/contributions/263009/attachments/165230/219522/hemeet_20230324_mcAtmNuScheme.pdf) 