### PR TITLE
RetrieveGHEPs added

### DIFF
--- a/nugen/EventGeneratorBase/GENIE/GENIE2ART.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GENIE2ART.cxx
@@ -11,7 +11,7 @@
 #include "GENIE2ART.h"
 //#include <math.h>
 //#include <map>
-//#include <fstream>
+#include <fstream>
 #include <memory>   // for unique_ptr
 #include <typeinfo>
 
@@ -791,6 +791,38 @@ genie::EventRecord* evgb::RetrieveGHEP(const simb::MCTruth& mctruth,
   */
 
   return newEvent;
+
+}
+
+//---------------------------------------------------------------------------
+std::vector<std::unique_ptr<genie::EventRecord>> evgb::RetrieveGHEPs(
+    const art::Handle<std::vector<simb::MCTruth>>& mcTruthHandle,
+    const art::Handle<std::vector<simb::GTruth>>& gTruthHandle){
+
+  std::vector<std::unique_ptr<genie::EventRecord>> gheps;
+
+  size_t NEventUnits = mcTruthHandle->size();
+  if (mcTruthHandle->size() != gTruthHandle->size()) {
+    NEventUnits = std::min(mcTruthHandle->size(), gTruthHandle->size());
+  }
+  for (size_t eu_it = 0; eu_it < NEventUnits; ++eu_it) {
+    gheps.emplace_back(evgb::RetrieveGHEP(mcTruthHandle->at(eu_it),
+                                          gTruthHandle->at(eu_it)));
+  }
+
+  return gheps;
+
+}
+
+std::vector<std::unique_ptr<genie::EventRecord>> evgb::RetrieveGHEPs(
+  const art::Event& e,
+  std::string mcTruthLabel,
+  std::string gTruthLabel){
+
+  art::Handle<std::vector<simb::MCTruth>> mcTruthHandle = e.getHandle<std::vector<simb::MCTruth>>(mcTruthLabel);
+  art::Handle<std::vector<simb::GTruth>> gTruthHandle = e.getHandle<std::vector<simb::GTruth>>(gTruthLabel);
+
+  return evgb::RetrieveGHEPs(mcTruthHandle, gTruthHandle);
 
 }
 

--- a/nugen/EventGeneratorBase/GENIE/GENIE2ART.h
+++ b/nugen/EventGeneratorBase/GENIE/GENIE2ART.h
@@ -11,6 +11,8 @@
 #define EVGB_GENIE2ART_H
 
 #include <string>
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
 
 /// GENIE neutrino interaction simulation objects
 namespace genie {
@@ -74,6 +76,16 @@ namespace evgb {
   genie::EventRecord* RetrieveGHEP(const simb::MCTruth& truth,
                                    const simb::GTruth&  gtruth,
                                    bool useFirstTrajPosition = true);
+
+  std::vector<std::unique_ptr<genie::EventRecord>> RetrieveGHEPs(
+    const art::Handle<std::vector<simb::MCTruth>>& mcTruthHandle,
+    const art::Handle<std::vector<simb::GTruth>>& gTruthHandle
+  );
+  std::vector<std::unique_ptr<genie::EventRecord>> RetrieveGHEPs(
+    const art::Event& e,
+    std::string mcTruthLabel,
+    std::string gTruthLabel
+  );
 
   void FillMCFlux(genie::GFluxI* fdriver, simb::MCFlux& mcflux);
 


### PR DESCRIPTION
Functions returns a vector of genie::EventRecord pointers are added. It uses the already existing function, `RetrieveGHEP` and simply making a vector of that. We plan to use this for nusystematics.