### PR TITLE
Adjust code as needed for Spack builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ cet_cmake_env()
 
 cet_set_compiler_flags(DIAGS CAUTIOUS WERROR
                        NO_UNDEFINED
-                       EXTRA_FLAGS -pedantic 
+                       EXTRA_FLAGS -pedantic
                                    $<$<COMPILE_LANGUAGE:CXX>:-Wno-unused-local-typedefs
                                          -Wno-variadic-macros>)
 cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)
@@ -39,7 +39,6 @@ find_package(cetlib_except REQUIRED)
 find_package(CLHEP REQUIRED)
 find_package(ROOT COMPONENTS Core Physics Geom GeomPainter MathMore EG TreePlayer FFTW EGPythia6 Gui Tree REQUIRED)
 find_package(dk2nudata REQUIRED)
-find_package(PostgreSQL REQUIRED)
 find_package(ifdh_art REQUIRED)
 find_package(log4cpp REQUIRED)
 find_package(GSL REQUIRED)

--- a/nugen/EventGeneratorBase/CMakeLists.txt
+++ b/nugen/EventGeneratorBase/CMakeLists.txt
@@ -1,3 +1,4 @@
+cet_make_library(LIBRARY_NAME EventGeneratorBase INTERFACE SOURCE evgenbase.h)
 
 install_headers()
 install_fhicl()


### PR DESCRIPTION
Adds `nugen::EventGeneratorBase` target, simplifying downstream use.  Also removes PostgreSQL dependency, which is not used.

**N.B.** These changes will also work for UPS builds.