### PR TITLE
use bare std::getenv() so as not to throw an exception if GENIE_PHYOPT_VARIANT is not set

### DIFF
--- a/nugen/EventGeneratorBase/GENIE/GENIE2ART.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GENIE2ART.cxx
@@ -317,9 +317,12 @@ void evgb::FillMCTruth(const genie::EventRecord *record,
   truth.SetOrigin(simb::kBeamNeutrino);
   std::unordered_map<std::string, std::string> genConfigCopy(genConfig);
   genConfigCopy.emplace("tune", genieTune);
-  std::string genie_phyopt_variant = evgb::ExpandEnvVar("$GENIE_PHYOPT_VARIANT");
-  if (genie_phyopt_variant != "" )
-    genConfigCopy.emplace("genie_phyopt_variant",genie_phyopt_variant);
+
+  const char* phyOptVar = std::getenv("GENIE_PHYOPT_VARIANT");
+  if ( phyOptVar != nullptr && std::strlen(phyOptVar) > 0 ) {
+    // it's set and of non-zero length
+    genConfigCopy.emplace("genie_phyopt_variant",phyOptVar);
+  }
 
   truth.SetGeneratorInfo(simb::Generator_t::kGENIE, genieVersion, genConfigCopy);
 


### PR DESCRIPTION
This protects against the case of genie_phyopt not being setup, or an version older than v3_06_00