### PR TITLE
Configure the CCQE calculator for non-form-factor CCQE knobs

### DIFF
--- a/nugen/NuReweight/GENIEReweight.h
+++ b/nugen/NuReweight/GENIEReweight.h
@@ -104,6 +104,7 @@ namespace rwgt{
 
     //Functions to configure individual weight calculators
     void ConfigureCCQE();
+    void ConfigureCCQEAxial();
     void ConfigureNCEL();
     void ConfigureQEVec();
     void ConfigureZexpVector();

--- a/nugen/NuReweight/art/NuReweight.cxx
+++ b/nugen/NuReweight/art/NuReweight.cxx
@@ -97,7 +97,57 @@
 #include "nusimdata/SimulationBase/GTruth.h"
 #include "nugen/NuReweight/art/NuReweight.h"
 
-namespace rwgt {
+namespace rwgt
+{
+  bool operator!=(const simb::GTruth & lhs, const simb::GTruth & rhs)
+  {
+    bool eq = lhs.fVertex == rhs.fVertex
+           && lhs.fweight == rhs.fweight
+           && lhs.fprobability == rhs.fprobability
+           && lhs.fXsec == rhs.fXsec
+           && lhs.fDiffXsec == rhs.fDiffXsec
+           && lhs.fGPhaseSpace == rhs.fGPhaseSpace
+           && lhs.fProbePDG == rhs.fProbePDG
+           && lhs.fProbeP4 == rhs.fProbeP4
+           && lhs.fTgtP4 == rhs.fTgtP4
+           && lhs.ftgtZ == rhs.ftgtZ
+           && lhs.ftgtA == rhs.ftgtA
+           && lhs.ftgtPDG == rhs.ftgtPDG
+           && lhs.fHitNucPDG == rhs.fHitNucPDG
+           && lhs.fHitQrkPDG == rhs.fHitQrkPDG
+           && lhs.fIsSeaQuark == rhs.fIsSeaQuark
+           && lhs.fHitNucP4 == rhs.fHitNucP4
+           && lhs.fHitNucPos == rhs.fHitNucPos
+           && lhs.fGscatter == rhs.fGscatter
+           && lhs.fGint == rhs.fGint
+           && lhs.fgQ2 == rhs.fgQ2
+           && lhs.fgq2 == rhs.fgq2
+           && lhs.fgW == rhs.fgW
+           && lhs.fgT == rhs.fgT
+           && lhs.fgX == rhs.fgX
+           && lhs.fgY == rhs.fgY
+           && lhs.fgWrun == rhs.fgWrun
+           && lhs.fFSleptonP4 == rhs.fFSleptonP4
+           && lhs.fFShadSystP4 == rhs.fFShadSystP4
+           && lhs.fIsCharm == rhs.fIsCharm
+           && lhs.fCharmHadronPdg == rhs.fCharmHadronPdg
+           && lhs.fStrangeHadronPdg == rhs.fStrangeHadronPdg
+           && lhs.fNumProton == rhs.fNumProton
+           && lhs.fNumNeutron == rhs.fNumNeutron
+           && lhs.fNumPi0 == rhs.fNumPi0
+           && lhs.fNumPiPlus == rhs.fNumPiPlus
+           && lhs.fNumPiMinus == rhs.fNumPiMinus
+           && lhs.fNumSingleGammas == rhs.fNumSingleGammas
+           && lhs.fNumRho0 == rhs.fNumRho0
+           && lhs.fNumRhoPlus == rhs.fNumRhoPlus
+           && lhs.fNumRhoMinus == rhs.fNumRhoMinus
+           && lhs.fResNum == rhs.fResNum
+           && lhs.fDecayMode == rhs.fDecayMode
+           && lhs.fFinalQuarkPdg == rhs.fFinalQuarkPdg
+           && lhs.fFinalLeptonPdg == rhs.fFinalLeptonPdg;
+   return !eq;
+  }
+
 
   ///<constructor
   NuReweight::NuReweight() {
@@ -111,11 +161,18 @@ namespace rwgt {
 
   double NuReweight::CalcWeight(const simb::MCTruth & truth, const simb::GTruth & gtruth) const {
 
-    genie::EventRecord* evr = evgb::RetrieveGHEP(truth, gtruth);
+  // do some rudimentary caching to prevent repeated requests for the same event
+  // from creating new genie::EventRecords over and over
+  static simb::GTruth cached_gtruth = simb::GTruth();
+  static std::unique_ptr<genie::EventRecord> evr = nullptr;
+  if (cached_gtruth != gtruth)
+  {
+    cached_gtruth = gtruth;
+    evr.reset(evgb::RetrieveGHEP(truth, gtruth));
+  }
 
     double wgt = this->CalculateWeight(*evr);
 
-    delete evr;
     //mf::LogVerbatim("GENIEReweight") << "New Event Weight is: " << wgt;
     return wgt;
   }


### PR DESCRIPTION
Confusingly, there are a couple of CCQE reweight knobs that are bundled in the same calculator that handles the axial-vector form factor treatment but don't have anything to do with form factors.  These were accidentally not configured in the GENIE 3 overhaul (see #14) so far, but this PR now enables them.

Probably this PR should actually be against `develop` after the previous commits from `nova_v3_19_br` are merged to `develop`, but we can discuss.  I've now done meaningful validation and the majority of the knobs generally otherwise look to be doing what they're supposed to.

The exception is M{a,v}{CC,NC}RES, which don't work because of a bug I found in GENIE.  I'm submitting PRs to GENIE and GENIE-Reweight to fix that, but it won't affect `nugen` apart from dependency versioning (since `nugen` depends on `dk2nu` which depends on `genie`, so the stack will need to be updated when a new release of GENIE becomes available).  PRs to those packages are submitted to GENIE already:
https://github.com/GENIE-MC/Generator/pull/452
https://github.com/GENIE-MC/Reweight/pull/39
