### PR TITLE
Make W2 formula use twice the nucleon mass for MEC events

### DIFF
--- a/nugen/EventGeneratorBase/GENIE/GENIE2ART.cxx
+++ b/nugen/EventGeneratorBase/GENIE/GENIE2ART.cxx
@@ -343,7 +343,8 @@ void evgb::FillMCTruth(const genie::EventRecord *record,
 #ifdef OLD_KINE_CALC
   //const TLorentzVector & p1 = (hitnucl) ? *(hitnucl->P4()) : pdummy;
 
-  double M  = genie::constants::kNucleonMass;
+  const int n_nucs = (procInfo.IsMEC()) ? 2 : 1;
+  const double M  = n_nucs * genie::constants::kNucleonMass;
   TLorentzVector q  = k1-k2;                     // q=k1-k2, 4-p transfer
   double Q2 = -1 * q.M2();                       // momemtum transfer
   double v  = (hitnucl) ? q.Energy()       : -1; // v (E transfer to the nucleus)
@@ -370,7 +371,8 @@ void evgb::FillMCTruth(const genie::EventRecord *record,
 #else
   if ( hitnucl || procInfo.IsCoherent() ) {
 #endif
-    const double M  = genie::constants::kNucleonMass;
+    const int n_nucs = (procInfo.IsMEC()) ? 2 : 1;
+    const double M  = n_nucs * genie::constants::kNucleonMass;
     // Bjorken x.
     // Rein & Sehgal use this same formulation of x even for Coherent
     x  = 0.5*Q2/(M*v);


### PR DESCRIPTION
During processing of SBND events, an event where the `simb::MCNeutrino` had `w = NaN` was discovered. 
This was tracked down to the calculation of kinematics in nugen, where the nucleon mass (== 0.5 * (Mn + Mp)) is used.

Formula:
```
W^2 = M^2 + 2 M v - Q^2,
```
where `W` is the hadronic invariant mass, `v` the transfer of energy from the neutrino to the hadronic system, and `Q^2`  the positive magnitude-squared of the 4-momentum transfer.

The EventRecord where this formula breaks down is:
```
|------------------------------------------------------------------------------------------------------------------|
|GENIE GHEP Event Record [print level:   3]                                                                        |
|------------------------------------------------------------------------------------------------------------------|
| Idx |          Name | Ist |        PDG |   Mother  | Daughter  |      Px |      Py |      Pz |       E |      m  |
|------------------------------------------------------------------------------------------------------------------|
|   0 |         nu_mu |   0 |         14 |  -1 |  -1 |   4 |   4 |   0.026 |  -0.046 |   1.693 |   1.693 |   0.000 |
|   1 |          Ar40 |   0 | 1000180400 |  -1 |  -1 |   2 |   3 |   0.000 |   0.000 |   0.000 |  37.216 |  37.216 |
|   2 |           n+p |  11 | 2000000201 |   1 |  -1 |   5 |   5 |  -0.298 |  -0.004 |  -0.160 |   1.908 |   1.878 |
|   3 |          Cl38 |   2 | 1000170380 |   1 |  -1 |  10 |  10 |   0.298 |   0.004 |   0.160 |  35.365 | *35.358 | M = 35.363
|   4 |           mu- |   1 |         13 |   0 |  -1 |  -1 |  -1 |  -0.771 |  -0.405 |   0.149 |   0.890 |   0.106 |
|   5 |           p+p |   3 | 2000000202 |   2 |  -1 |   6 |   7 |   0.499 |   0.355 |   1.383 |   2.654 | **1.877 | M = 2.181
|   6 |        proton |  14 |       2212 |   5 |  -1 |   8 |   8 |   0.258 |   0.441 |   0.142 |   1.078 |   0.938 | FSI = 1
|   7 |        proton |  14 |       2212 |   5 |  -1 |   9 |   9 |   0.242 |  -0.085 |   1.241 |   1.576 |   0.938 | FSI = 1
|   8 |        proton |   1 |       2212 |   6 |  -1 |  -1 |  -1 |   0.258 |   0.441 |   0.142 |   1.078 |   0.938 |
|   9 |        proton |   1 |       2212 |   7 |  -1 |  -1 |  -1 |   0.242 |  -0.085 |   1.241 |   1.576 |   0.938 |
|  10 |      HadrBlob |  15 | 2000000002 |   3 |  -1 |  -1 |  -1 |   0.298 |   0.004 |   0.160 |  35.365 | **0.000 | M = 35.363
|------------------------------------------------------------------------------------------------------------------|
|       Fin-Init:                                                |  -0.000 |  -0.000 |  -0.000 |   0.000 |         |
|------------------------------------------------------------------------------------------------------------------|
|       Vertex:          nu_mu @ (x =     0.63232 m, y =    -1.92440 m, z =     2.60529 m, t =    6.876511e-08 s)  |
|------------------------------------------------------------------------------------------------------------------|
| Err flag [bits:15->0] : 0000000000000000    |  1st set:                                                     none |
| Err mask [bits:15->0] : 1111111111111111    |  Is unphysical:    NO |   Accepted:   YES                          |
|------------------------------------------------------------------------------------------------------------------|
| sig(Ev) =       6.76909e-38 cm^2  | dsig(Ev;{K_s})/dK   =     0.00000e+00 cm^2/{K}   | Weight =          1.00000 |
|------------------------------------------------------------------------------------------------------------------|

--------------------------------------------------------------------------------------------------------------
GENIE Interaction Summary
--------------------------------------------------------------------------------------------------------------
[-] [Init-State]
 |--> probe        : PDG-code = 14 (nu_mu)
 |--> nucl. target : Z = 18, A = 40, PDG-Code = 1000180400 (Ar40)
 |--> hit nucleon  : no set
 |--> hit quark    : no set
 |--> probe 4P     : (E =     1.693424, Px =     0.026073, Py =    -0.045751, Pz =     1.692605)
 |--> target 4P    : (E =    37.215526, Px =     0.000000, Py =     0.000000, Pz =     0.000000)

[-] [Process-Info]
 |--> Interaction : Weak[CC]
 |--> Scattering  : MEC
[-] [Kinematics]
 |--> *Selected* Bjorken x = 0.829216
 |--> *Selected* Inelasticity y = 0.474284
 |--> *Selected* Momentum transfer Q2 (>0) = 2.501265
 |--> *Selected* Momentum transfer q2 (<0) = -2.501265
 |--> *Selected* Hadronic invariant mass W = 2.010331
[-] [Exclusive Process Info]
 |--> charm prod.  : false |--> strange prod.  : false
 |--> f/s nucleons : N(p) = 0 N(n) = 0
 |--> f/s pions    : N(pi^0) = 0 N(pi^+) = 0 N(pi^-) = 0
 |--> f/s Other    : N(gamma) = 0 N(Rho^0) = 0 N(Rho^+) = 0 N(Rho^-) = 0
 |--> resonance    : [not set]
 |--> final quark prod.  : false
 |--> final lepton prod.  : false
--------------------------------------------------------------------------------------------------------------
```

Applying the formula, it is:
```
M = genie::constants::kNucleonMass = 0.9389 GeV
v = Enu - Emu = 0.803 GeV
Q^2 = 2.501 GeV^2

==> W^2 = 0.9389^2 + 2 * 0.9389 * 0.803 - 2.501 = -0.1116 < 0.
```

Using `M --> 2M` for MEC, one gets:
```
W^2 = (2 * 0.9389)^2 + 2 * (2 * 0.9389) * 0.803 - 2.501 = 4.041 > 0 ==> W = 2.01 GeV,
```
which matches the selected W = 2.010331 GeV.

This PR is marked draft while testing is performed with SBND CAFMaker.